### PR TITLE
chore: laptop-migration cleanup — work() helper, zsh productivity, drop yabai bindings

### DIFF
--- a/skhd/skhdrc
+++ b/skhd/skhdrc
@@ -1,47 +1,14 @@
-# Navigation
-alt - h : yabai -m window --focus west
-alt - j : yabai -m window --focus south
-alt - k : yabai -m window --focus north
-alt - l : yabai -m window --focus east
+# App launchers
+# --------------
 
-# Moving windows
-shift + alt - h : yabai -m window --warp west
-shift + alt - j : yabai -m window --warp south
-shift + alt - k : yabai -m window --warp north
-shift + alt - l : yabai -m window --warp east
-
-# Make window native fullscreen
-alt - f         : yabai -m window --toggle zoom-fullscreen
-shift + alt - f : yabai -m window --toggle native-fullscreen
-
-# toggle window split type
-alt - e : yabai -m window --toggle split
-
-# Move focus container to workspace
-shift + alt - m : yabai -m window --space last && yabai -m space --focus last
-shift + alt - p : yabai -m window --space prev && yabai -m space --focus prev
-shift + alt - n : yabai -m window --space next && yabai -m space --focus next
-shift + alt - 1 : yabai -m window --space 1 && yabai -m space --focus 1
-shift + alt - 2 : yabai -m window --space 2 && yabai -m space --focus 2
-shift + alt - 3 : yabai -m window --space 3 && yabai -m space --focus 3
-shift + alt - 4 : yabai -m window --space 4 && yabai -m space --focus 4
-shift + alt - 5 : yabai -m window --space 5 && yabai -m space --focus 5
-shift + alt - 6 : yabai -m window --space 6 && yabai -m space --focus 6
-
-# Kill a container
-shift + alt - q : yabai -m window --close
-
-# Float or unfloat a window
-shift + alt - space : yabai -m window --toggle float
-
-# open terminal, blazingly fast compared to iTerm/Hyper
+# open kitty terminal (single-instance is fast: subsequent presses open a new window in the existing process)
 cmd - return : /Applications/kitty.app/Contents/MacOS/kitty --single-instance -d ~
 
-# # open qutebrowser
-# cmd + shift - return : ~/Scripts/qtb.sh
-
-# open mpv
+# open mpv with the currently copied URL
 cmd - m : open -na /Applications/mpv.app $(pbpaste)
 
-# Open brave
+# open brave
 cmd + shift - return : open -n -a "Brave Browser"
+
+# # open qutebrowser (disabled)
+# cmd + shift - return : ~/Scripts/qtb.sh

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -20,8 +20,11 @@ export NVM_DIR="$HOME/.nvm"
 export CLUSTER_LOGIN_SSO=true
 
 # PATH Modifications
-PATH="$PATH:/Users/pthapa/App:/Applications/Visual Studio Code.app/Contents/Resources/app/bin:/usr/local/go/bin" 
+PATH="$PATH:/Users/pthapa/App:/Applications/Visual Studio Code.app/Contents/Resources/app/bin:/usr/local/go/bin:/Users/pthapa/darwin-arm64" 
 PATH=$(go env GOPATH)/bin:/Library/Frameworks/Python.framework/Versions/3.7/bin:$PATH
+
+# Fox: 'xterm-kitty': unknown terminal type.
+export TERM=xterm-256color
 
 # Exports Management System
 export EXPORTS_DIR="$HOME/.config/exports"
@@ -140,6 +143,31 @@ work() {
 alias oma='/Users/pthapa/Documents/src/github/personal/oh-my-aliases/oma'
 alias sd="cd ~ && \$(find Documents work Desktop Downloads -type d -maxdepth 4 | fzf)"
 
+
+# =============================================================================
+# Kubectl Debug SHELL Access
+# =============================================================================
+
+# Quick node debug access
+alias kshell='kubectl debug node/$1 -it --image=ubuntu'
+
+# Node debug with auto-chroot
+alias knodeshell='f() { kubectl debug node/$1 -it --image=ubuntu -- chroot /host bash; }; f'
+
+# Combined function for the full workflow
+kdebugnode() {
+    if [ -z "$1" ]; then
+        echo "Usage: kdebugnode <node-name>"
+        return 1
+    fi
+    echo "Connecting to node $1..."
+    kubectl debug node/$1 -it --image=ubuntu -- chroot /host bash
+}
+
+
+# Podman
+alias pt-podman="podman run --rm --name promtool -w /app -v $(pwd):/app --entrypoint promtool prom/prometheus:latest test rules tests/*"
+
 # =============================================================================
 # GIT ALIASES & FUNCTIONS
 # =============================================================================
@@ -155,6 +183,7 @@ alias gpsh='git push'
 alias gpo='git push -u origin `git symbolic-ref --short HEAD`'
 alias glg='git log'
 alias gl="git log --graph --format=format:'%C(bold blue)%h%C(reset) - %C(bold green)(%ar)%C(reset) %C(white)%an%C(reset)%C(bold yellow)%d%C(reset) %C(dim white)- %s%C(reset)' --all"
+alias gfr='git fetch origin master && git rebase origin/master --reapply-cherry-picks'
 
 # Git Diff Aliases
 alias gd='git diff'
@@ -682,12 +711,14 @@ alias sw-pre-prd="switch_profile pre-prod"
 alias sw-prd="switch_profile prod"
 
 # Cluster Login Shortcuts
-alias dev='cia cluster login --cluster=dev --profile=pre-prod && export AWS_PROFILE=pre-prod && kx dev'
-alias tst='cia cluster login --cluster=sre-test --profile=pre-prod && export AWS_PROFILE=pre-prod && kx sre-test'
-alias stg='cia cluster login --cluster=devtest --profile=prod && export AWS_PROFILE=prod && kx devtest'
-alias prd='cia cluster login --cluster=production --profile=prod && export AWS_PROFILE=prod && kx production'
-alias pit='cia cluster login --cluster=prd-internal --profile=prod && export AWS_PROFILE=prod && kx prd-internal'
-alias pex='cia cluster login --cluster=prd-external --profile=prod && export AWS_PROFILE=prod && kx prd-external'
+export HELMFILE_GOCCY_GOYAML=true
+
+alias dev='export HELMFILE_ENVIRONMENT=dev && cia role assume --profile=pre-prod --account=capsulerx-pre-prod --role=admin && export AWS_PROFILE=pre-prod && cia cluster login --cluster=dev --profile=pre-prod && export AWS_PROFILE=pre-prod && kx dev'
+alias tst='export HELMFILE_ENVIRONMENT=sre-test && cia role assume --profile=pre-prod --account=capsulerx-pre-prod --role=admin && export AWS_PROFILE=pre-prod && cia cluster login --cluster=sre-test --profile=pre-prod && export AWS_PROFILE=pre-prod && kx sre-test'
+alias stg='export HELMFILE_ENVIRONMENT=devtest && cia role assume --profile=prod --account=capsulerx --role=admin && export AWS_PROFILE=prod && cia cluster login --cluster=devtest --profile=prod && export AWS_PROFILE=prod && kx devtest'
+alias prd='export HELMFILE_ENVIRONMENT=production && cia role assume --profile=prod --account=capsulerx --role=admin && export AWS_PROFILE=prod && cia cluster login --cluster=production --profile=prod && export AWS_PROFILE=prod && kx production'
+alias pit='export HELMFILE_ENVIRONMENT=prd-internal && cia role assume --profile=prod --account=capsulerx --role=admin && export AWS_PROFILE=prod && cia cluster login --cluster=prd-internal --profile=prod && export AWS_PROFILE=prod && kx prd-internal'
+alias pex='export HELMFILE_ENVIRONMENT=prd-external && cia role assume --profile=prod --account=capsulerx --role=admin && export AWS_PROFILE=prod && cia cluster login --cluster=prd-external --profile=prod && export AWS_PROFILE=prod && kx prd-external'
 
 # Authentication Shortcuts
 alias wai='cia auth whoami'
@@ -708,6 +739,16 @@ function lolbanner() {
     figlet -f ~/.local/share/fonts/3d.flf $* | lolcat
     echo
 }
+
+function run_agent() {
+    local name="$1"
+    local task="$2"
+    echo "Starting agent: $name"
+    claude -w "$name" -n "$name" -p "$task. When done, create a PR with gh pr create." \
+      --allowedTools "Bash,Read,Edit,Write,Grep,Glob" \
+      --output-format json > "/tmp/agent-$name.json" 2>&1
+    echo "Agent $name finished"
+  }
 
 # Network Diagnostics
 alias ruok='

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -112,6 +112,31 @@ alias hgrep='history | grep'
 alias grep2="grep -v '^\s*$\|^\s*\#' $1"
 mkcd() { mkdir -p "$1" && cd "$1"; }
 gccd() { git clone "$1" && cd "$(basename "$1" .git)"; }
+
+# Clone + set up a repo for working in one step:
+#   1) Clone CapsuleHealth/<repo> to ~/work/<repo> if missing
+#   2) Restore <repo>.env from the 1Password Employee vault if a Secure Note
+#      named "<repo> .env" exists AND the repo has no .env yet
+#   3) cd into it
+work() {
+  local repo="$1"
+  if [ -z "$repo" ]; then echo "usage: work <repo>" >&2; return 1; fi
+  local dir="$HOME/work/$repo"
+  if [ ! -d "$dir" ]; then
+    gh repo clone "CapsuleHealth/$repo" "$dir" || return 1
+  fi
+  if [ ! -f "$dir/.env" ] && command -v op >/dev/null 2>&1 && op account list >/dev/null 2>&1; then
+    local env_value
+    env_value=$(op item get "$repo .env" --format json 2>/dev/null \
+      | jq -r '.fields[] | select(.purpose=="NOTES") | .value' 2>/dev/null)
+    if [ -n "$env_value" ] && [ "$env_value" != "null" ]; then
+      printf '%s' "$env_value" > "$dir/.env"
+      echo "restored $dir/.env from 1Password"
+    fi
+  fi
+  cd "$dir"
+}
+
 alias oma='/Users/pthapa/Documents/src/github/personal/oh-my-aliases/oma'
 alias sd="cd ~ && \$(find Documents work Desktop Downloads -type d -maxdepth 4 | fzf)"
 


### PR DESCRIPTION
## Summary
Companion to `CapsuleHealth/sre-workstation-setup#2`. Lands the work that belongs in this (live, symlinked) dotfiles repo:

- **`work()` helper** (zsh) — `work <repo>` clones `CapsuleHealth/<repo>` to `~/work/<repo>` if missing, restores `<repo> .env` from the 1Password Employee vault if present, then `cd`s in
- **zsh productivity additions**:
  - kubectl node-debug (`kshell`, `knodeshell`, `kdebugnode`)
  - `pt-podman` promtool wrapper
  - `gfr` (fetch + rebase --reapply-cherry-picks)
  - `HELMFILE_GOCCY_GOYAML=true` + cluster-login aliases now chain `cia role assume` and set `HELMFILE_ENVIRONMENT`
  - `run_agent` claude-launcher function
  - `TERM=xterm-256color` (workaround for `xterm-kitty` unknown on non-kitty shells)
  - `PATH` includes `~/darwin-arm64`
- **skhd**: drop all yabai-based bindings (`alt - h/j/k/l`, `shift+alt` warp/space/q/space). Yabai is removed from the workstation; those bindings would silently no-op. Keep only the launcher bindings (`Cmd+Enter` → kitty, `Cmd+M` → mpv, `Cmd+Shift+Enter` → Brave)

## Deliberately not included
- `git/.gitconfig` has pending changes in the working tree containing a GitHub PAT embedded in a `url.insteadOf` line. **Not committed** — pushing that to a public repo would leak the token. Will be handled separately (token rotation + move credential management to `gh auth setup-git` / keychain).

## Test plan
- [ ] `source ~/.zshrc` — no errors, `work` function is defined
- [ ] `work sherlock` clones (or skips) and cds; restores `.env` if the Secure Note exists
- [ ] `Cmd+Enter` still launches kitty; `Cmd+M` still works for mpv
- [ ] Removed yabai bindings no longer run anything